### PR TITLE
Generate plugin for golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ is multiline`)
 </td></tr>
 </tbody></table>
 
-Functions from `github.com/stretchr/testify/assert` and `github.com/stretchr/testify/require` are ignored by default (see [config](#config)).
+Functions from `github.com/stretchr/testify/assert` and `github.com/stretchr/testify/require` are ignored by default (see [config](#flag--ignore-func-calls)).
 
 </details>
 
@@ -415,38 +415,46 @@ func Bar() (int, interface {
 ## Usage
 
 
-The best way is to use [golangci-lint](https://golangci-lint.run/).  
-It includes [pairedbrackets](https://golangci-lint.run/usage/linters/#list-item-pairedbrackets) and a lot of other great linters.
+You can use [golangci-lint](https://golangci-lint.run/).  
+Unfortunately, v1 was rejected to be a built-in linter (hopefully v2 will be accepted).
+You can configure `pairedbrackets` as a [plugin](https://golangci-lint.run/contributing/new-linters#how-to-add-a-private-linter-to-golangci-lint).
 
-### Install
+### Install `golangci-lint`
 
-See [official site](https://golangci-lint.run/usage/install/).
+Prebuilt binaries doesn't support plugins (see [discussion](https://github.com/golangci/golangci-lint/discussions/3361)), so you have to build golangci-lint:
+```shell
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+```
 
-### Enable
+### Install `pairedbrackets`
+
+```shell
+go install github.com/maratori/pairedbrackets@latest
+```
+
+### Build plugin
+
+```shell
+pairedbrackets -build-golangci-lint-plugin
+```
+
+`pairedbrackets.so` will be created in current working directory. You can change the output path with flag `-plugin-output` (see other flags in help as well).
+
+### Config
 
 `pairedbrackets` is disabled by default.  
 To enable it, add the following to your `.golangci.yml`:
 
 ```yaml
+linters-settings:
+  custom:
+     pairedbrackets:
+        path: /path/to/plugin/pairedbrackets.so
+        description: The linter checks formatting of paired brackets
+        original-url: github.com/maratori/pairedbrackets
 linters:
   enable:
      pairedbrackets
-```
-
-### Config
-
-Here is available configuration:
-```yaml
-linters-settings:
-  pairedbrackets:
-    # List of regexp patterns of fully qualified function calls to ignore.
-    # Example of fully qualified function: github.com/stretchr/testify/require.Equal
-    # Example of fully qualified method: (*github.com/stretchr/testify/assert.Assertions).Equal
-    # Default: ["github.com/stretchr/testify/assert", "github.com/stretchr/testify/require"]
-    ignore-func-calls:
-      - github.com/stretchr/testify/assert
-      - github.com/stretchr/testify/require
-      - ^fmt\.
 ```
 
 ### Run

--- a/main.go
+++ b/main.go
@@ -1,10 +1,150 @@
 package main
 
 import (
+	"embed"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+
 	"github.com/maratori/pairedbrackets/pkg/pairedbrackets"
 	"golang.org/x/tools/go/analysis/singlechecker"
 )
 
+//go:embed pkg
+//go:embed plugin
+//go:embed go.*
+var self embed.FS
+
+const (
+	buildFlagName    = "build-golangci-lint-plugin"
+	buildFlagDefault = false
+	buildFlagUsage   = "build plugin for your version of golangci-lint, see other flags"
+
+	goPathFlagName    = "go-path"
+	goPathFlagDefault = "go"
+	goPathFlagUsage   = "path to go executable, is used only with -" + buildFlagName
+
+	linterFlagName    = "golangci-lint"
+	linterFlagDefault = "golangci-lint"
+	linterFlagUsage   = "path to golangci-lint executable, is used only with -" + buildFlagName
+
+	outputFlagName    = "plugin-output"
+	outputFlagDefault = "pairedbrackets.so"
+	outputFlagUsage   = "plugin output path, is used only with -" + buildFlagName
+)
+
 func main() {
-	singlechecker.Main(pairedbrackets.NewAnalyzer())
+	set := flag.NewFlagSet("", flag.ContinueOnError)
+	set.SetOutput(io.Discard)
+	build := set.Bool(buildFlagName, buildFlagDefault, buildFlagUsage)
+	goPath := set.String(goPathFlagName, goPathFlagDefault, goPathFlagUsage)
+	linter := set.String(linterFlagName, linterFlagDefault, linterFlagUsage)
+	output := set.String(outputFlagName, outputFlagDefault, outputFlagUsage)
+	if set.Parse(os.Args[1:]) == nil && *build {
+		err := buildPlugin(*goPath, *linter, *output)
+		if err != nil {
+			fmt.Println(err) //nolint:forbidigo // better than log
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	analyzer := pairedbrackets.NewAnalyzer()
+	set.VisitAll(func(f *flag.Flag) {
+		analyzer.Flags.Var(f.Value, f.Name, f.Usage) // for documentation
+	})
+	singlechecker.Main(analyzer)
+}
+
+func buildPlugin(goPath string, linterPath string, outputPath string) error {
+	linterPath, err := exec.LookPath(linterPath)
+	if err != nil {
+		return fmt.Errorf("golangci-lint not found: %w", err)
+	}
+
+	goPath, err = exec.LookPath(goPath)
+	if err != nil {
+		return fmt.Errorf("go not found: %w", err)
+	}
+
+	outputPath, err = filepath.Abs(outputPath)
+	if err != nil {
+		return fmt.Errorf("can't get absolute output path: %w", err)
+	}
+
+	output, err := exec.Command(goPath, "version", "-m", linterPath).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("can't get version of golangci-lint dependencies: %w", err)
+	}
+
+	match := regexp.MustCompile(`dep\s+golang.org/x/tools\s+(v\S+)`).FindSubmatch(output)
+	if len(match) == 0 {
+		return errors.New("golang.org/x/tools not found in golangci-lint dependencies")
+	}
+	lib := "golang.org/x/tools@" + string(match[1])
+
+	temp, err := os.MkdirTemp("", "")
+	if err != nil {
+		return fmt.Errorf("temp dir not created: %w", err)
+	}
+	defer os.RemoveAll(temp)
+
+	err = fs.WalkDir(self, ".", func(path string, d fs.DirEntry, errX error) error {
+		if errX != nil {
+			return errX
+		}
+
+		fullPath := filepath.Join(temp, path)
+
+		if d.IsDir() {
+			return os.MkdirAll(fullPath, 0700)
+		}
+
+		content, errX := fs.ReadFile(self, path)
+		if errX != nil {
+			return errX
+		}
+
+		errX = os.WriteFile(fullPath, content, 0600)
+		if errX != nil {
+			return errX
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("can't write pairedbrackets src: %w", err)
+	}
+
+	err = os.Chdir(temp)
+	if err != nil {
+		return fmt.Errorf("can't change wording directory: %w", err)
+	}
+
+	output, err = exec.Command(goPath, "get", lib).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("can't get %s: %w\n%s", lib, err, output)
+	}
+
+	output, err = exec.Command(
+		goPath,
+		"build",
+		"-buildmode=plugin",
+		"-o",
+		outputPath,
+		"plugin/pairedbrackets.go",
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("can't build plugin: %w\n%s", err, output)
+	}
+
+	fmt.Printf("pairedbrackets.so is built with %s\n", lib) //nolint:forbidigo // better than log
+
+	return nil
 }

--- a/plugin/pairedbrackets.go
+++ b/plugin/pairedbrackets.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/maratori/pairedbrackets/pkg/pairedbrackets"
+	"golang.org/x/tools/go/analysis"
+)
+
+var /* const */ AnalyzerPlugin = Plugin{} //nolint:gochecknoglobals // const
+
+type Plugin struct{}
+
+func (Plugin) GetAnalyzers() []*analysis.Analyzer {
+	return []*analysis.Analyzer{
+		pairedbrackets.NewAnalyzer(),
+	}
+}

--- a/plugin/pairedbrackets_test.go
+++ b/plugin/pairedbrackets_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlugin(t *testing.T) {
+	analyzers := AnalyzerPlugin.GetAnalyzers()
+	require.Len(t, analyzers, 1)
+	require.Equal(t, "pairedbrackets", analyzers[0].Name)
+}


### PR DESCRIPTION
Because v1 was [rejected](https://github.com/golangci/golangci-lint/pull/3225) by golangci-lint team, have to create plugin.